### PR TITLE
Add test-one usage to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Conflict-free replicated data types for Pony.
 ```bash
 make                    # build tests + examples (release)
 make test               # same as above
+make test-one t=TestName    # run a single test by name
 make config=debug       # debug build
 make examples           # examples only
 make clean              # clean build artifacts + corral cache


### PR DESCRIPTION
Documents the `test-one` Makefile target for running individual tests by name: `make test-one t=TestName`