### PR TITLE
Cut AGENTS.md to what the code cannot tell an agent

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,42 +24,21 @@ When you start working on this project, load the `pony-skills` skill — it tell
 Read [CONTRIBUTING.md](CONTRIBUTING.md).
 <!-- /contributor-only -->
 
-## Building and Testing
+## Building and testing
 
 ```bash
-make                    # build tests + examples (release)
-make test               # same as above
-make test-one t=TestName    # run a single test by name
-make config=debug       # debug build
-make examples           # examples only
-make clean              # clean build artifacts + corral cache
+make                     # build + run tests, build examples (test is the default)
+make test                # same as make
+make test-one t=TestName # run a single test by name
+make examples            # examples only
+make config=debug        # debug build
+make clean               # clean build artifacts + corral cache
 ```
 
-## Project Status
+## Design
 
-The API might change but it is usable in production software.
+Every CRDT is delta-state: a mutator both applies the change and returns a convergent delta that can be merged into any replica. `Convergent` and `Causal` are traits rather than interfaces because they carry private methods (`_create_in`, `_converge_empty_in`). Hash-based types come in pairs — a convenience alias over `HashEq` (for example `GSet`) and a generic class parameterized by `HashFunction` (for example `GHashSet`).
 
-## Project Structure
+## Conventions
 
-All source files live in `crdt/` (flat layout, no subpackages). Test files are prefixed with `_test_` or `_prop_` and use `_`-prefixed class names for privacy. The test runner is `crdt/_test.pony`.
-
-### CRDT Types
-
-- **Counters**: `GCounter` (g_counter.pony), `PNCounter` (pn_counter.pony), `CCounter` (c_counter.pony)
-- **Sets**: `GSet`/`GHashSet` (g_set.pony), `P2Set`/`P2HashSet` (p2_set.pony), `TSet`/`THashSet` (t_set.pony), `AWORSet`/`AWORHashSet` (awor_set.pony), `RWORSet`/`RWORHashSet` (rwor_set.pony)
-- **Registers**: `TReg` (t_reg.pony), `MVReg`/`MVHashReg` (mv_reg.pony)
-- **Collections**: `TLog` (t_log.pony), `CKeyspace`/`HashCKeyspace` (c_keyspace.pony)
-
-### Interfaces and Internal Abstractions
-
-- **Interfaces**: `Convergent` (convergent.pony, trait), `Replicated` (replicated.pony, interface), `Causal` (causal.pony, trait)
-- **Types**: `ID` (id.pony), `Bias*` primitives (bias.pony)
-- **Serialization**: `Tokens`/`TokensIterator` (tokens.pony)
-- **Internal**: `_Dot` (_dot.pony), `DotContext` (dot_context.pony), `DotKernel` (dot_kernel.pony), `DotKernelSingle` (dot_kernel_single.pony), `DotChecklist` (dot_checklist.pony), `Eq`/`EqIs`/`EqTuple2` (eq.pony), `_Math` (_math.pony), `_DefaultValueFn` (_default_value_fn.pony)
-
-## Key Design Patterns
-
-- All CRDT mutator methods accept and return a convergent delta-state
-- `Convergent` and `Causal` are traits (not interfaces) because they have private methods (`_create_in`, `_converge_empty_in`)
-- Hash-based types come in pairs: a convenience type alias (e.g., `GSet`) using `HashEq` and a generic class (e.g., `GHashSet`) parameterized by `HashFunction`
-- `CKeyspace` composes CRDTs under named keys with a shared `DotContext`
+- Test files are prefixed `_test_` or `_prop_` (property tests), use `_`-prefixed private class names, and are registered in `crdt/_test.pony`.


### PR DESCRIPTION
AGENTS.md was 65 lines — CRDT-type and interface enumerations, a source listing, and a project-status note. Applying the pony-agents-md principle, this keeps the commands, the delta-state design invariant (with the paired-hash-type shape and the traits-not-interfaces rationale), and the test-file-naming convention.