### PR TITLE
Annotate test classes with \nodoc\ to exclude them from docs

### DIFF
--- a/crdt/_test_awor_set.pony
+++ b/crdt/_test_awor_set.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestAWORSet is UnitTest
+class \nodoc\ _TestAWORSet is UnitTest
   new iso create() => None
   fun name(): String => "crdt.AWORSet"
 
@@ -84,7 +84,7 @@ class _TestAWORSet is UnitTest
     h.assert_eq[AWORSet[String]](b, c)
     h.assert_eq[AWORSet[String]](c, a)
 
-class _TestAWORSetDelta is UnitTest
+class \nodoc\ _TestAWORSetDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.AWORSet (ẟ)"
 
@@ -166,7 +166,7 @@ class _TestAWORSetDelta is UnitTest
     h.assert_eq[AWORSet[String]](b, c)
     h.assert_eq[AWORSet[String]](c, a)
 
-class _TestAWORSetTokens is UnitTest
+class \nodoc\ _TestAWORSetTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.AWORSet (tokens)"
 

--- a/crdt/_test_c_counter.pony
+++ b/crdt/_test_c_counter.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestCCounter is UnitTest
+class \nodoc\ _TestCCounter is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CCounter"
 
@@ -61,7 +61,7 @@ class _TestCCounter is UnitTest
     h.assert_eq[CCounter](b, c)
     h.assert_eq[CCounter](c, a)
 
-class _TestCCounterDelta is UnitTest
+class \nodoc\ _TestCCounterDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CCounter (ẟ)"
 
@@ -122,7 +122,7 @@ class _TestCCounterDelta is UnitTest
     h.assert_eq[CCounter](b, c)
     h.assert_eq[CCounter](c, a)
 
-class _TestCCounterTokens is UnitTest
+class \nodoc\ _TestCCounterTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CCounter (tokens)"
 

--- a/crdt/_test_c_keyspace.pony
+++ b/crdt/_test_c_keyspace.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestCKeyspace is UnitTest
+class \nodoc\ _TestCKeyspace is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CKeyspace"
 
@@ -85,7 +85,7 @@ class _TestCKeyspace is UnitTest
     // h.assert_eq[U64](try a("currant")?.value() else 0xDEAD end, 0xDEAD)
     // h.assert_eq[U64](try a("date")?.value() else 0xDEAD end, 0xDEAD)
 
-class _TestCKeyspaceDelta is UnitTest
+class \nodoc\ _TestCKeyspaceDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CKeyspace (ẟ)"
 
@@ -159,7 +159,7 @@ class _TestCKeyspaceDelta is UnitTest
     // h.assert_eq[U64](try a("currant")?.value() else 0xDEAD end, 0xDEAD)
     // h.assert_eq[U64](try a("date")?.value() else 0xDEAD end, 0xDEAD)
 
-class _TestCKeyspaceTokens is UnitTest
+class \nodoc\ _TestCKeyspaceTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.CKeyspace (tokens)"
 

--- a/crdt/_test_g_counter.pony
+++ b/crdt/_test_g_counter.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestGCounter is UnitTest
+class \nodoc\ _TestGCounter is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GCounter"
 
@@ -61,7 +61,7 @@ class _TestGCounter is UnitTest
     h.assert_eq[GCounter](b, c)
     h.assert_eq[GCounter](c, a)
 
-class _TestGCounterDelta is UnitTest
+class \nodoc\ _TestGCounterDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GCounter (ẟ)"
 
@@ -122,7 +122,7 @@ class _TestGCounterDelta is UnitTest
     h.assert_eq[GCounter](b, c)
     h.assert_eq[GCounter](c, a)
 
-class _TestGCounterTokens is UnitTest
+class \nodoc\ _TestGCounterTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GCounter (tokens)"
 
@@ -150,7 +150,7 @@ class _TestGCounterTokens is UnitTest
       h.fail("failed to parse token stream")
     end
 
-class _TestGCounterMax is UnitTest
+class \nodoc\ _TestGCounterMax is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GCounter (max)"
   fun apply(h: TestHelper) =>

--- a/crdt/_test_g_set.pony
+++ b/crdt/_test_g_set.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestGSet is UnitTest
+class \nodoc\ _TestGSet is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GSet"
 
@@ -36,7 +36,7 @@ class _TestGSet is UnitTest
     h.assert_eq[GSet[String]](b, c)
     h.assert_eq[GSet[String]](c, a)
 
-class _TestGSetDelta is UnitTest
+class \nodoc\ _TestGSetDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GSet (ẟ)"
 
@@ -72,7 +72,7 @@ class _TestGSetDelta is UnitTest
     h.assert_eq[GSet[String]](b, c)
     h.assert_eq[GSet[String]](c, a)
 
-class _TestGSetTokens is UnitTest
+class \nodoc\ _TestGSetTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.GSet (tokens)"
 

--- a/crdt/_test_mv_reg.pony
+++ b/crdt/_test_mv_reg.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestMVReg is UnitTest
+class \nodoc\ _TestMVReg is UnitTest
   new iso create() => None
   fun name(): String => "crdt.MVReg"
 
@@ -50,7 +50,7 @@ class _TestMVReg is UnitTest
     h.assert_eq[MVReg[String]](b, c)
     h.assert_eq[MVReg[String]](c, a)
 
-class _TestMVRegDelta is UnitTest
+class \nodoc\ _TestMVRegDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.MVReg (ẟ)"
 
@@ -100,7 +100,7 @@ class _TestMVRegDelta is UnitTest
     h.assert_eq[MVReg[String]](b, c)
     h.assert_eq[MVReg[String]](c, a)
 
-class _TestMVRegTokens is UnitTest
+class \nodoc\ _TestMVRegTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.MVReg (tokens)"
 

--- a/crdt/_test_p2_set.pony
+++ b/crdt/_test_p2_set.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestP2Set is UnitTest
+class \nodoc\ _TestP2Set is UnitTest
   new iso create() => None
   fun name(): String => "crdt.P2Set"
 
@@ -63,7 +63,7 @@ class _TestP2Set is UnitTest
     h.assert_eq[P2Set[String]](b, c)
     h.assert_eq[P2Set[String]](c, a)
 
-class _TestP2SetDelta is UnitTest
+class \nodoc\ _TestP2SetDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.P2Set (ẟ)"
 
@@ -126,7 +126,7 @@ class _TestP2SetDelta is UnitTest
     h.assert_eq[P2Set[String]](b, c)
     h.assert_eq[P2Set[String]](c, a)
 
-class _TestP2SetTokens is UnitTest
+class \nodoc\ _TestP2SetTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.P2Set (tokens)"
 

--- a/crdt/_test_pn_counter.pony
+++ b/crdt/_test_pn_counter.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestPNCounter is UnitTest
+class \nodoc\ _TestPNCounter is UnitTest
   new iso create() => None
   fun name(): String => "crdt.PNCounter"
 
@@ -61,7 +61,7 @@ class _TestPNCounter is UnitTest
     h.assert_eq[PNCounter](b, c)
     h.assert_eq[PNCounter](c, a)
 
-class _TestPNCounterDelta is UnitTest
+class \nodoc\ _TestPNCounterDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.PNCounter (ẟ)"
 
@@ -122,7 +122,7 @@ class _TestPNCounterDelta is UnitTest
     h.assert_eq[PNCounter](b, c)
     h.assert_eq[PNCounter](c, a)
 
-class _TestPNCounterTokens is UnitTest
+class \nodoc\ _TestPNCounterTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.PNCounter (tokens)"
 

--- a/crdt/_test_rwor_set.pony
+++ b/crdt/_test_rwor_set.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestRWORSet is UnitTest
+class \nodoc\ _TestRWORSet is UnitTest
   new iso create() => None
   fun name(): String => "crdt.RWORSet"
 
@@ -84,7 +84,7 @@ class _TestRWORSet is UnitTest
     h.assert_eq[RWORSet[String]](b, c)
     h.assert_eq[RWORSet[String]](c, a)
 
-class _TestRWORSetDelta is UnitTest
+class \nodoc\ _TestRWORSetDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.RWORSet (ẟ)"
 
@@ -166,7 +166,7 @@ class _TestRWORSetDelta is UnitTest
     h.assert_eq[RWORSet[String]](b, c)
     h.assert_eq[RWORSet[String]](c, a)
 
-class _TestRWORSetTokens is UnitTest
+class \nodoc\ _TestRWORSetTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.RWORSet (tokens)"
 

--- a/crdt/_test_t_log.pony
+++ b/crdt/_test_t_log.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestTLog is UnitTest
+class \nodoc\ _TestTLog is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TLog"
 
@@ -176,7 +176,7 @@ class _TestTLog is UnitTest
     h.assert_eq[USize](0, b.size())
     h.assert_eq[USize](0, c.size())
 
-class _TestTLogDelta is UnitTest
+class \nodoc\ _TestTLogDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TLog (ẟ)"
 
@@ -327,7 +327,7 @@ class _TestTLogDelta is UnitTest
     h.assert_eq[USize](0, b.size())
     h.assert_eq[USize](0, c.size())
 
-class _TestTLogTokens is UnitTest
+class \nodoc\ _TestTLogTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TLog (tokens)"
 

--- a/crdt/_test_t_reg.pony
+++ b/crdt/_test_t_reg.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestTReg is UnitTest
+class \nodoc\ _TestTReg is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TReg"
 
@@ -55,7 +55,7 @@ class _TestTReg is UnitTest
     h.assert_eq[U64](b.timestamp(), 5)
     h.assert_eq[U64](c.timestamp(), 5)
 
-class _TestTRegDelta is UnitTest
+class \nodoc\ _TestTRegDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TReg (ẟ)"
 
@@ -110,7 +110,7 @@ class _TestTRegDelta is UnitTest
     h.assert_eq[U64](b.timestamp(), 5)
     h.assert_eq[U64](c.timestamp(), 5)
 
-class _TestTRegTokens is UnitTest
+class \nodoc\ _TestTRegTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TReg (tokens)"
 

--- a/crdt/_test_t_set.pony
+++ b/crdt/_test_t_set.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-class _TestTSet is UnitTest
+class \nodoc\ _TestTSet is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TSet"
 
@@ -71,7 +71,7 @@ class _TestTSet is UnitTest
     h.assert_eq[TSet[String]](b, c)
     h.assert_eq[TSet[String]](c, a)
 
-class _TestTSetDelta is UnitTest
+class \nodoc\ _TestTSetDelta is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TSet (ẟ)"
 
@@ -142,7 +142,7 @@ class _TestTSetDelta is UnitTest
     h.assert_eq[TSet[String]](b, c)
     h.assert_eq[TSet[String]](c, a)
 
-class _TestTSetTokens is UnitTest
+class \nodoc\ _TestTSetTokens is UnitTest
   new iso create() => None
   fun name(): String => "crdt.TSet (tokens)"
 

--- a/crdt/_test_tokens.pony
+++ b/crdt/_test_tokens.pony
@@ -1,6 +1,6 @@
 use "pony_test"
 
-primitive _TestTokensWellFormed
+primitive \nodoc\ _TestTokensWellFormed
   fun apply(h: TestHelper, tokens: Tokens, loc: SourceLoc = __loc) =>
     var expected: USize = 1
     var actual:   USize = 0


### PR DESCRIPTION
The test classes, primitives, and actors are excluded from generated documentation by the `\nodoc\` annotation. Most already carried it; the `_test_*.pony` files did not. This adds it to the 38 declarations that were missing it, bringing them in line with the rest of the test code.

The `type _CounterOp` alias in `_prop_c_counter.pony` is left unannotated: the compiler rejects `\nodoc\` on a type alias, which is why the convention covers classes, primitives, and actors but not type aliases.