### PR TITLE
Add linting section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,10 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 If you are running on an Anthropic model, use `claude-opus-4-6` for writing comments, documentation, and other prose. Prose quality from Anthropic models dropped starting with Opus 4.7 and has gotten worse with each subsequent release.
 
+## Linting
+
+Run `make lint` before considering any work done. Fix all issues it reports. `make lint` runs pony-lint, which checks for style and correctness problems in Pony source files. A clean lint run is part of "done" — don't open a PR or report completion with lint issues outstanding.
+
 ## Building and testing
 
 ```bash


### PR DESCRIPTION
Adds a Linting section to AGENTS.md that requires AI assistants to run `make lint` and fix all reported issues before considering work done.
