### PR TITLE
Update to work with Pony 0.69.0

### DIFF
--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,10 +18,10 @@ permissions:
 
 jobs:
   vs-ponyc-release:
-    name: Test against recent ponyc release
+    name: Test against recent ponyc nightly
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test

--- a/.release-notes/update-for-pony-0.69.0.md
+++ b/.release-notes/update-for-pony-0.69.0.md
@@ -1,0 +1,3 @@
+## Update to work with Pony 0.69.0
+
+Pony 0.69.0 is the new minimum required version.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See the `examples/` directory for usage demonstrations of each type.
 
 ## Installation
 
+* Requires ponyc 0.69.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/crdt.git --version 0.1.0`
 * `corral fetch` to fetch your dependencies

--- a/crdt/dot_kernel_single.pony
+++ b/crdt/dot_kernel_single.pony
@@ -154,8 +154,8 @@ class ref DotKernelSingle[A: Any val] is Replicated
     // seen in our history of dots should be added to our map of active values.
     for (id', (n, value)) in that._map.pairs() do
       let dot = (id', n)
-      if (_map.get_or_else(id', (0, value))._1 < n)
-        and (not _ctx.contains(dot))
+      if (_map.get_or_else(id', (0, value))._1 < n) and
+        (not _ctx.contains(dot))
       then
         _map(id') = (n, value)
         changed = true

--- a/crdt/t_reg.pony
+++ b/crdt/t_reg.pony
@@ -81,8 +81,8 @@ class ref TReg[
   fun ref _update_no_delta(value': A, timestamp': T): Bool =>
     if
       (timestamp' > _timestamp) or (
-        (timestamp' == _timestamp)
-      and
+        (timestamp' == _timestamp) and
+
         iftype B <: BiasGreater
         then value' > _value
         else value' < _value


### PR DESCRIPTION
Fix pony-lint operator-spacing violations, declare ponyc 0.69.0 as the minimum required version, and switch PR CI to nightly until 0.69.0 releases.